### PR TITLE
test: bug rolling update clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌟 HNSW + Postgresql Indexer
+# 🌟 HNSW + PostgreSQL Indexer
 
 HNSWPostgreSQLIndexer Jina is a production-ready, scalable Indexer for the Jina neural search framework.
 
@@ -39,6 +39,6 @@ You can perform all the usual operations on the respective endpoints
 - `/index`. Add new data to PostgreSQL
 - `/search`. Query the HNSW index with your Documents.
 - `/update`. Update documents in PostgreSQL
-- `/delete`. Delete documents in PostgreSQL. **Note**. This only performs soft-deletion by default. This is done in order to not break the look-up of the document id after doing a search. For a hard delete, add `'soft_delete': False'` to `parameters` 
+- `/delete`. Delete documents in PostgreSQL. **Note**. This only performs soft-deletion by default. This is done in order to not break the look-up of the document id after doing a search. For a hard delete, add `'soft_delete': False'` to `parameters`. You might also perform a cleanup after a full rebuild of the HNSW index, by calling `/cleanup`.
 
 

--- a/executor/hnswlib_searcher.py
+++ b/executor/hnswlib_searcher.py
@@ -323,7 +323,7 @@ class HnswlibSearcher:
 
     def sync(self, delta: GENERATOR_DELTA):
         if delta is None:
-            self.logger.warning('No data received in Faiss._add_delta. Skipping...')
+            self.logger.warning('No data received in HNSW.sync. Skipping...')
             return
 
         for doc_id, vec_array, doc_timestamp in delta:

--- a/executor/hnswpsql.py
+++ b/executor/hnswpsql.py
@@ -54,6 +54,7 @@ class HNSWPostgresIndexer(Executor):
         return_embeddings: bool = True,
         dry_run: bool = False,
         partitions: int = 128,
+        mute_unique_warnings: bool = False,
         **kwargs,
     ):
         """
@@ -86,6 +87,7 @@ class HNSWPostgresIndexer(Executor):
         :param dry_run: (PSQL) If True, no database connection will be built
         :param partitions: (PSQL) the number of shards to distribute
          the data (used when syncing into HNSW)
+        :param mute_unique_warnings: (PSQL) whether to mute warnings about unique ids constraint failing (useful when indexing with shards and polling = 'all')
 
         NOTE:
 

--- a/executor/postgres_indexer.py
+++ b/executor/postgres_indexer.py
@@ -34,6 +34,7 @@ class PostgreSQLStorage:
         dry_run: bool = False,
         partitions: int = 128,
         dump_dtype: type = np.float64,
+        mute_unique_warnings: bool = False,
         *args,
         **kwargs,
     ):
@@ -51,6 +52,9 @@ class PostgreSQLStorage:
         :param dry_run: If True, no database connection will be build.
         :param partitions: the number of shards to distribute
          the data (used when rolling update on Searcher side)
+         :param mute_unique_warnings: whether to mute warnings about unique
+        ids constraint failing (useful when indexing with shards and
+        polling = 'all')
         """
         self.default_traversal_paths = traversal_paths
         self.hostname = hostname
@@ -72,6 +76,7 @@ class PostgreSQLStorage:
             dry_run=dry_run,
             partitions=partitions,
             dump_dtype=dump_dtype,
+            mute_unique_warnings=mute_unique_warnings,
         )
         self.default_return_embeddings = return_embeddings
 

--- a/executor/postgres_indexer.py
+++ b/executor/postgres_indexer.py
@@ -283,3 +283,10 @@ class PostgreSQLStorage:
         """
         with self.handler as postgres_handler:
             postgres_handler.clear()
+
+    @property
+    def initialized(self, **kwargs):
+        """
+        Whether the PSQL connection has been initialized
+        """
+        return hasattr(self.handler, 'postgreSQL_pool')

--- a/executor/postgreshandler.py
+++ b/executor/postgreshandler.py
@@ -74,6 +74,12 @@ class PostgreSQLHandler:
                 port=port,
             )
             self._init_table()
+        else:
+            self.logger.info(
+                'PSQL started in dry run mode. Will not connect to '
+                'PSQL service. Needs to be restarted to connect '
+                'again, with `dry_run=False`'
+            )
 
     def __enter__(self):
         self.connection = self._get_connection()
@@ -239,9 +245,8 @@ class PostgreSQLHandler:
         have been marked for soft-deletion
         """
         cursor = self.connection.cursor()
-        psycopg2.extras.execute_batch(
-            cursor,
-            f'DELETE FROM {self.table} ' f'WHERE doc == NULL',
+        cursor.execute(
+            f'DELETE FROM {self.table} WHERE doc is NULL',
         )
         self.connection.commit()
         return
@@ -466,3 +471,10 @@ class PostgreSQLHandler:
         cursor.execute(f'DELETE FROM {self.table}')
         self.connection.commit()
         return
+
+    @property
+    def initialized(self, **kwargs):
+        """
+        Whether the PSQL connection has been initialized
+        """
+        return hasattr(self, 'postgreSQL_pool')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,3 +31,8 @@ def get_documents():
             yield d
 
     return get_documents_inner
+
+
+@pytest.fixture()
+def runtime_args():
+    return {'pea_id': 0, 'replica_id': 0, 'parallel': 1}

--- a/tests/integration/test_hnsw_psql.py
+++ b/tests/integration/test_hnsw_psql.py
@@ -6,6 +6,7 @@ from typing import Dict
 import pytest
 from executor.hnswpsql import HNSWPostgresIndexer
 from jina import DocumentArray, Flow, Executor, requests
+from jina.logging.profile import TimeContext
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 compose_yml = os.path.abspath(os.path.join(cur_dir, '..', 'docker-compose.yml'))
@@ -98,23 +99,25 @@ def test_basic_integration(docker_compose, get_documents):
 
 
 @pytest.mark.parametrize('docker_compose', [compose_yml], indirect=['docker_compose'])
-def test_replicas_integration(docker_compose, get_documents):
-    emb_size = 10
+@pytest.mark.parametrize('nr_docs', [100])
+@pytest.mark.parametrize('nr_search_docs', [10])
+@pytest.mark.parametrize('emb_size', [10])
+def test_replicas_integration(
+    docker_compose, get_documents, nr_docs, nr_search_docs, emb_size, benchmark=False
+):
     LIMIT = 10
     NR_SHARDS = 2
-    docs = DocumentArray(get_documents(nr=100, emb_size=emb_size))
+    NR_REPLICAS = 3
+    docs = get_documents(nr=nr_docs, emb_size=emb_size)
 
-    uses_with = {
-        'dim': emb_size,
-        'limit': LIMIT,
-    }
+    uses_with = {'dim': emb_size, 'limit': LIMIT, 'mute_unique_warnings': True}
 
     f = Flow().add(
         name='indexer',
         uses=HNSWPostgresIndexer,
         uses_with=uses_with,
         parallel=NR_SHARDS,
-        replicas=3,
+        replicas=NR_REPLICAS,
         # this will lead to warnings on PSQL for clashing ids
         # but required in order for the query request is sent
         # to all the shards
@@ -123,20 +126,63 @@ def test_replicas_integration(docker_compose, get_documents):
     )
 
     with f:
-        f.post('/index', docs)
+        request_size = 100
+        if benchmark:
+            request_size = 1000
+
+        with TimeContext(f'indexing {nr_docs}'):
+            f.post('/index', docs, request_size=request_size)
+
+        status = dict(f.post('/status', return_results=True)[0].docs[0].tags)
+        assert int(status['psql_docs']) == nr_docs
+        assert int(status['hnsw_docs']) == 0
 
         search_docs = DocumentArray(
-            get_documents(index_start=len(docs), emb_size=emb_size)
+            get_documents(index_start=nr_docs, nr=nr_search_docs, emb_size=emb_size)
         )
 
-        result = f.post('/search', search_docs, return_results=True)
-        search_docs = result[0].docs
-        assert len(search_docs[0].matches) == 0
+        if not benchmark:
+            result = f.post('/search', search_docs, return_results=True)
+            search_docs = result[0].docs
+            assert len(search_docs[0].matches) == 0
 
-        f.rolling_update(pod_name='indexer', uses_with=uses_with)
-        result = f.post('/search', search_docs, return_results=True)
+        with TimeContext(
+            f'rolling update {NR_REPLICAS} replicas x {NR_SHARDS} ' f'shards'
+        ):
+            f.rolling_update(pod_name='indexer', uses_with=uses_with)
+
+        status = dict(f.post('/status', return_results=True)[0].docs[0].tags)
+        assert int(status['psql_docs']) == nr_docs
+        assert int(status['hnsw_docs']) >= nr_docs // NR_SHARDS
+
+        with TimeContext(f'search with {nr_search_docs}'):
+            result = f.post('/search', search_docs, return_results=True)
         search_docs = result[0].docs
         assert len(search_docs[0].matches) == NR_SHARDS * LIMIT
+
+
+def in_docker():
+    """Returns: True if running in a Docker container, else False"""
+    with open('/proc/1/cgroup', 'rt') as ifh:
+        if 'docker' in ifh.read():
+            print('in docker, skipping benchmark')
+            return True
+        return False
+
+
+@pytest.mark.parametrize('docker_compose', [compose_yml], indirect=['docker_compose'])
+def test_benchmark_basic(docker_compose, get_documents):
+    nr_docs = 1000000
+    if in_docker() or ('GITHUB_WORKFLOW' in os.environ):
+        nr_docs = 1000
+    return test_replicas_integration(
+        docker_compose=docker_compose,
+        nr_docs=nr_docs,
+        get_documents=get_documents,
+        nr_search_docs=10,
+        emb_size=128,
+        benchmark=True,
+    )
 
 
 @pytest.mark.parametrize('docker_compose', [compose_yml], indirect=['docker_compose'])

--- a/tests/unit/test_basic.py
+++ b/tests/unit/test_basic.py
@@ -1,3 +1,4 @@
+import datetime
 import os.path
 
 import pytest
@@ -8,22 +9,26 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
 compose_yml = os.path.abspath(os.path.join(cur_dir, '..', 'docker-compose.yml'))
 
 
-def test_basic():
-    indexer = HNSWPostgresIndexer(dry_run=True, startup_sync=False)
+def test_basic(runtime_args):
+    indexer = HNSWPostgresIndexer(
+        dry_run=True, startup_sync=False, runtime_args=runtime_args
+    )
     assert isinstance(indexer._vec_indexer, HnswlibSearcher)
     assert isinstance(indexer._kv_indexer, PostgreSQLStorage)
     assert indexer._init_kwargs is not None
+    status = dict(indexer.status()[0].tags)
+    assert status['psql_docs'] is None
+    assert status['hnsw_docs'] == 0.0  # protobuf converts ints to floats
+    assert datetime.datetime.fromisoformat(status['last_sync']) == datetime.datetime.min
 
 
 @pytest.mark.parametrize('docker_compose', [compose_yml], indirect=['docker_compose'])
-def test_docker(docker_compose, get_documents):
+def test_docker(docker_compose, get_documents, runtime_args):
     emb_size = 10
 
     docs = DocumentArray(get_documents(emb_size=emb_size))
 
-    indexer = HNSWPostgresIndexer(
-        dim=emb_size, runtime_args={'pea_id': 0, 'replica_id': 0, 'parallel': 1}
-    )
+    indexer = HNSWPostgresIndexer(dim=emb_size, runtime_args=runtime_args)
     assert isinstance(indexer._vec_indexer, HnswlibSearcher)
     assert isinstance(indexer._kv_indexer, PostgreSQLStorage)
     assert indexer._init_kwargs is not None

--- a/tests/unit/test_basic.py
+++ b/tests/unit/test_basic.py
@@ -44,3 +44,9 @@ def test_docker(docker_compose, get_documents, runtime_args):
     indexer.sync({})
     indexer.search(search_docs, {})
     assert len(search_docs[0].matches) > 0
+
+    indexer.clear()
+    status_response = indexer.status()
+    status = dict(status_response[0].tags)
+    assert status['psql_docs'] == 0
+    assert status['hnsw_docs'] == 0


### PR DESCRIPTION
if you remove from `tests/integration/test_hnsw_psql.py`

L:180 
```
        if benchmark:
            f.post('/clear')
```

the test `test_benchmark_basic` fails when it runs the second case

even though clear is called at the beginning of the flow.

Why?

yes, /clear only hits one replica.
but when we restart the flow there should be completely new replicas anyway